### PR TITLE
check if playlist is on user's list already

### DIFF
--- a/GoodQuestion.Services/PlaylistServices.cs
+++ b/GoodQuestion.Services/PlaylistServices.cs
@@ -133,16 +133,25 @@ namespace GoodQuestion.Services
                 var query = ctx
                     .Users
                     .Single(u => u.Id == _userId.ToString());
+
                 foreach (Playlist playlist in playlistsToAdd)
                 {
+                    var queryPlaylist = ctx
+                        .Playlists
+                        .Where(u => u.PlaylistId == playlist.PlaylistId)
+                        .SingleOrDefault();
+
                     if (!CheckIfPlaylistExists(playlist.PlaylistId))
                     {
                         ctx.Playlists.Add(playlist);
                         changeCount++;
                     }
 
-                    query.Playlists.Add(playlist);
-                    changeCount++;
+                    if (!query.Playlists.Contains(queryPlaylist))
+                    {
+                        query.Playlists.Add(playlist);
+                        changeCount++;
+                    }
 
                     if (changeCount >= 1)
                     {


### PR DESCRIPTION
fixed error in adding playlists where app attempted to add a duplicate playlist to a user's list of playlists, making it blow up